### PR TITLE
Add vendor Marvell

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -22,6 +22,7 @@ const (
 	VendorAMD                   = "amd"
 	VendorHynix                 = "hynix"
 	VendorSamsung               = "samsung"
+	VendorMarvell               = "marvell"
 	SystemManufacturerUndefined = "To Be Filled By O.E.M."
 
 	// Generic component slugs
@@ -110,6 +111,8 @@ func FormatVendorName(name string) string {
 		return VendorAmericanMegatrends
 	case strings.Contains(v, VendorSamsung):
 		return VendorSamsung
+	case strings.Contains(v, VendorMarvell):
+		return VendorMarvell
 	default:
 		return name
 	}
@@ -136,6 +139,8 @@ func VendorFromString(s string) string {
 		return VendorMellanox
 	case strings.Contains(s, "infineon"):
 		return VendorInfineon
+	case strings.Contains(s, "1b4b-9230"):
+		return VendorMarvell
 	default:
 		return ""
 	}

--- a/constants.go
+++ b/constants.go
@@ -55,6 +55,8 @@ const (
 	SmartStatusOK      = "ok"
 	SmartStatusFailed  = "failed"
 	SmartStatusUnknown = "unknown"
+
+	VendorMarvellPciID = "1b4b"
 )
 
 // FormatVendorName compares the given strings to identify and returned a known
@@ -139,7 +141,7 @@ func VendorFromString(s string) string {
 		return VendorMellanox
 	case strings.Contains(s, "infineon"):
 		return VendorInfineon
-	case strings.Contains(s, "1b4b-9230"):
+	case strings.Contains(s, VendorMarvell), strings.Contains(s, VendorMarvellPciID):
 		return VendorMarvell
 	default:
 		return ""

--- a/device.go
+++ b/device.go
@@ -207,3 +207,13 @@ type Drive struct {
 	CapableSpeedGbps    int64    `json:"capable_speed_gbps,omitempty"`
 	NegotiatedSpeedGbps int64    `json:"negotiated_speed_gbps,omitempty"`
 }
+
+// VirtualDisk models RAID arrays
+type VirtualDisk struct {
+	ID             string   `json:"id,omitempty"`
+	Name           string   `json:"name,omitempty"`
+	RaidType       string   `json:"raid_type,omitempty"`
+	SizeBytes      int64    `json:"size_bytes,omitempty"`
+	Status         string   `json:"status,omitempty"`
+	PhysicalDrives []*Drive `json:"physical_drives,omitempty"`
+}

--- a/device.go
+++ b/device.go
@@ -176,6 +176,8 @@ type StorageController struct {
 	PhysicalID                   string `json:"physid,omitempty"`
 	BusInfo                      string `json:"bus_info,omitempty"`
 	SpeedGbps                    int64  `json:"speed_gbps,omitempty"`
+	MaxPhysicalDisks             int    `json:"max_physical_disks,omitempty"`
+	MaxVirtualDisks              int    `json:"max_virtual_disks,omitempty"`
 }
 
 // Mainboard component

--- a/device.go
+++ b/device.go
@@ -14,6 +14,8 @@ type Common struct {
 	Firmware    *Firmware         `json:"firmware,omitempty"`
 	Status      *Status           `json:"status,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
+	PCIVendorID  string            `json:"pci_vendor_id,omitempty"`
+	PCIProductID string            `json:"pci_product_id,omitempty"`
 }
 
 // Device type is composed of various components


### PR DESCRIPTION
This PR adds a vendor name mapping for Marvell and one of their product ids for identification.