### PR TITLE
device: Add LogicalName field to Device.Common

### DIFF
--- a/device.go
+++ b/device.go
@@ -10,6 +10,7 @@ type Common struct {
 	Model       string            `json:"model,omitempty"`
 	Serial      string            `json:"serial,omitempty"`
 	ProductName string            `json:"product_name,omitempty"`
+	LogicalName string            `json:"logical_name,omitempty"`
 	Firmware    *Firmware         `json:"firmware,omitempty"`
 	Status      *Status           `json:"status,omitempty"`
 	Metadata    map[string]string `json:"metadata,omitempty"`


### PR DESCRIPTION
## What does this PR implement/change/remove?

Add LogicalName field to Device.Common, the LogicalName is the kernel name assigned to a device.


