### PR TITLE
constants.go: Add SlugRAIDImpl constants for RAID implementations

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -57,6 +57,11 @@ const (
 	SmartStatusUnknown = "unknown"
 
 	VendorMarvellPciID = "1b4b"
+
+	// RAID implementations
+	SlugRAIDImplLinuxSoftware = "linuxsw"
+	SlugRAIDImplZFS           = "zfs"
+	SlugRAIDImplHardware      = "hardware"
 )
 
 // FormatVendorName compares the given strings to identify and returned a known


### PR DESCRIPTION
## What does this PR implement/change/remove?

Adds a set of Slug constants covering various RAID implementations.