### PR TITLE
VendorConfigManager implementations for dell, supermicro and asrockrack

### DIFF
--- a/config/asrockrack.go
+++ b/config/asrockrack.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"encoding/xml"
+	"strings"
+)
+
+type asrockrackVendorConfig struct {
+	ConfigFormat string
+	ConfigData   *asrockrackConfig
+}
+
+type asrockrackConfig struct {
+	BiosCfg *asrockrackBiosCfg `xml:"BiosCfg"`
+}
+
+type asrockrackBiosCfg struct {
+	XMLName xml.Name                 `xml:"BiosCfg"`
+	Menus   []*asrockrackBiosCfgMenu `xml:"Menu"`
+}
+
+type asrockrackBiosCfgMenu struct {
+	XMLName  xml.Name                    `xml:"Menu"`
+	Name     string                      `xml:"name,attr"`
+	Settings []*asrockrackBiosCfgSetting `xml:"Setting"`
+	Menus    []*asrockrackBiosCfgMenu    `xml:"Menu"`
+}
+
+type asrockrackBiosCfgSetting struct {
+	XMLName        xml.Name `xml:"Setting"`
+	Name           string   `xml:"Name,attr"`
+	Order          string   `xml:"order,attr"`
+	SelectedOption string   `xml:"selectedOption,attr"`
+	Type           string   `xml:"type,attr"`
+}
+
+func NewAsrockrackVendorConfigManager(configFormat string) (VendorConfigManager, error) {
+	asrr := &asrockrackVendorConfig{}
+
+	switch strings.ToLower(configFormat) {
+	case "json":
+		asrr.ConfigFormat = strings.ToLower(configFormat)
+	default:
+		return nil, UnknownConfigFormatError(strings.ToLower(configFormat))
+	}
+
+	asrr.ConfigData = &asrockrackConfig{
+		BiosCfg: &asrockrackBiosCfg{},
+	}
+
+	return asrr, nil
+}
+
+// FindMenu locates an existing asrockrackBiosCfgMenu if one exists in the ConfigData, if not
+// it creates one and returns a pointer to that.
+func (cm *asrockrackVendorConfig) FindMenu(menuName string) (m *asrockrackBiosCfgMenu) {
+	for _, m = range cm.ConfigData.BiosCfg.Menus {
+		if m.Name == menuName {
+			return
+		}
+	}
+
+	m.Name = menuName
+
+	cm.ConfigData.BiosCfg.Menus = append(cm.ConfigData.BiosCfg.Menus, m)
+
+	return
+}
+
+// FindMenuSetting locates an existing asrockrackBiosCfgSetting if one exists in the
+// ConfigData, if not it creates one and returns a pointer to that.
+func (cm *asrockrackVendorConfig) FindMenuSetting(m *asrockrackBiosCfgMenu, name string) (s *asrockrackBiosCfgSetting) {
+	for _, s = range m.Settings {
+		if s.Name == name {
+			return
+		}
+	}
+
+	s.Name = name
+
+	m.Settings = append(m.Settings, s)
+
+	return
+}
+
+// TODO(jwb) How do we handle the random nature of sub menus here..   we could make the user pass the explicit pointer to a menu struct, or..
+func (cm *asrockrackVendorConfig) Raw(name, value string, menuPath []string) {
+}
+
+func (cm *asrockrackVendorConfig) Marshal() (string, error) {
+	switch strings.ToLower(cm.ConfigFormat) {
+	case "xml":
+		x, err := xml.Marshal(cm.ConfigData)
+		if err != nil {
+			return "", err
+		}
+
+		return string(x), nil
+	default:
+		return "", UnknownConfigFormatError(strings.ToLower(cm.ConfigFormat))
+	}
+}
+
+// Generic config options
+
+func (cm *asrockrackVendorConfig) EnableTPM() {
+	// Unimplemented
+}
+
+func (cm *asrockrackVendorConfig) EnableSRIOV() {
+	// Unimplemented
+}

--- a/config/asrockrack.go
+++ b/config/asrockrack.go
@@ -54,6 +54,10 @@ func NewAsrockrackVendorConfigManager(configFormat string, vendorOptions map[str
 // FindMenu locates an existing asrockrackBiosCfgMenu if one exists in the ConfigData, if not
 // it creates one and returns a pointer to that.
 func (cm *asrockrackVendorConfig) FindMenu(menuName string) (m *asrockrackBiosCfgMenu) {
+	if cm.ConfigData.BiosCfg.Menus == nil {
+		return
+	}
+
 	for _, m = range cm.ConfigData.BiosCfg.Menus {
 		if m.Name == menuName {
 			return

--- a/config/asrockrack.go
+++ b/config/asrockrack.go
@@ -34,7 +34,7 @@ type asrockrackBiosCfgSetting struct {
 	Type           string   `xml:"type,attr"`
 }
 
-func NewAsrockrackVendorConfigManager(configFormat string) (VendorConfigManager, error) {
+func NewAsrockrackVendorConfigManager(configFormat string, vendorOptions map[string]string) (VendorConfigManager, error) {
 	asrr := &asrockrackVendorConfig{}
 
 	switch strings.ToLower(configFormat) {

--- a/config/dell.go
+++ b/config/dell.go
@@ -34,8 +34,8 @@ type dellComponent struct {
 type dellComponentAttribute struct {
 	XMLName     xml.Name `xml:"Attribute"`
 	Name        string   `xml:"Name,attr" json:"Name"`
-	SetOnImport bool     `json:"SetOnImport,omitempty"`
-	Comment     string   `json:"Comment,omitempty"`
+	SetOnImport bool     `xml:"SetOnImport,omitempty" json:"SetOnImport,omitempty"`
+	Comment     string   `xml:"Comment,omitempty" json:"Comment,omitempty"`
 	Value       string   `xml:",chardata" json:"Value"`
 }
 
@@ -54,6 +54,12 @@ func NewDellVendorConfigManager(configFormat string) (VendorConfigManager, error
 	}
 
 	return dell, nil
+}
+
+func (cm *dellVendorConfig) SetSystemConfiguration(model, servicetag, timestamp string) {
+	cm.ConfigData.SystemConfiguration.Model = model
+	cm.ConfigData.SystemConfiguration.ServiceTag = servicetag
+	cm.ConfigData.SystemConfiguration.TimeStamp = timestamp
 }
 
 // FindComponent locates an existing DellComponent if one exists in the ConfigData, if not

--- a/config/dell.go
+++ b/config/dell.go
@@ -39,7 +39,7 @@ type dellComponentAttribute struct {
 	Value       string   `xml:",chardata" json:"Value"`
 }
 
-func NewDellVendorConfigManager(configFormat string) (VendorConfigManager, error) {
+func NewDellVendorConfigManager(configFormat string, vendorOptions map[string]string) (VendorConfigManager, error) {
 	dell := &dellVendorConfig{}
 
 	switch strings.ToLower(configFormat) {
@@ -53,13 +53,15 @@ func NewDellVendorConfigManager(configFormat string) (VendorConfigManager, error
 		SystemConfiguration: &dellSystemConfiguration{},
 	}
 
+	dell.setSystemConfiguration(vendorOptions["model"], vendorOptions["servicetag"])
 	return dell, nil
 }
 
-func (cm *dellVendorConfig) SetSystemConfiguration(model, servicetag, timestamp string) {
+func (cm *dellVendorConfig) setSystemConfiguration(model, servicetag string) {
 	cm.ConfigData.SystemConfiguration.Model = model
 	cm.ConfigData.SystemConfiguration.ServiceTag = servicetag
-	cm.ConfigData.SystemConfiguration.TimeStamp = timestamp
+	// TODO(jwb) Make this 'now'
+	cm.ConfigData.SystemConfiguration.TimeStamp = "Tue Nov  2 21:19:16 2021"
 }
 
 // FindComponent locates an existing DellComponent if one exists in the ConfigData, if not

--- a/config/dell.go
+++ b/config/dell.go
@@ -53,6 +53,7 @@ func NewDellVendorConfigManager(configFormat string, vendorOptions map[string]st
 	}
 
 	dell.setSystemConfiguration(vendorOptions["model"], vendorOptions["servicetag"])
+
 	return dell, nil
 }
 
@@ -114,12 +115,14 @@ func (cm *dellVendorConfig) Marshal() (string, error) {
 		if err != nil {
 			return "", err
 		}
+
 		return string(x), nil
 	case "json":
 		x, err := json.Marshal(cm.ConfigData.SystemConfiguration)
 		if err != nil {
 			return "", err
 		}
+
 		return string(x), nil
 	default:
 		return "", UnknownConfigFormatError(strings.ToLower(cm.ConfigFormat))

--- a/config/dell.go
+++ b/config/dell.go
@@ -102,14 +102,14 @@ func (cm *dellVendorConfig) Raw(name, value string, menuPath []string) {
 func (cm *dellVendorConfig) Marshal() (string, error) {
 	switch strings.ToLower(cm.ConfigFormat) {
 	case "xml":
-		x, err := xml.Marshal(cm.ConfigData)
+		x, err := xml.Marshal(cm.ConfigData.SystemConfiguration)
 		if err != nil {
 			return "", err
 		}
 
 		return string(x), nil
 	case "json":
-		x, err := json.Marshal(cm.ConfigData)
+		x, err := json.Marshal(cm.ConfigData.SystemConfiguration)
 		if err != nil {
 			return "", err
 		}

--- a/config/dell.go
+++ b/config/dell.go
@@ -64,7 +64,11 @@ func (cm *dellVendorConfig) FindComponent(fqdd string) (c *dellComponent) {
 		}
 	}
 
-	c.FQDD = fqdd
+	c = &dellComponent{
+		XMLName:    xml.Name{},
+		FQDD:       fqdd,
+		Attributes: []*dellComponentAttribute{},
+	}
 
 	cm.ConfigData.SystemConfiguration.Components = append(cm.ConfigData.SystemConfiguration.Components, c)
 
@@ -80,7 +84,9 @@ func (cm *dellVendorConfig) FindComponentAttribute(c *dellComponent, name string
 		}
 	}
 
-	a.Name = name
+	a = &dellComponentAttribute{
+		Name: name,
+	}
 
 	c.Attributes = append(c.Attributes, a)
 

--- a/config/dell.go
+++ b/config/dell.go
@@ -3,7 +3,6 @@ package config
 import (
 	"encoding/json"
 	"encoding/xml"
-	"fmt"
 	"strings"
 )
 
@@ -19,7 +18,7 @@ type dellConfig struct {
 type dellSystemConfiguration struct {
 	XMLName    xml.Name         `xml:"SystemConfiguration"`
 	Model      string           `xml:"Model,attr" json:"Model"`
-	Comments   []string         `xml:"Comments>Comment,omitempty" json:"Comments,omitempty" `
+	Comments   []string         `xml:"Comments>Comment,omitempty" json:"Comments,omitempty"`
 	ServiceTag string           `xml:"ServiceTag,attr" json:"ServiceTag"`
 	TimeStamp  string           `xml:"TimeStamp,attr" json:"TimeStamp"`
 	Components []*dellComponent `xml:"Component" json:"Components"`
@@ -115,16 +114,12 @@ func (cm *dellVendorConfig) Marshal() (string, error) {
 		if err != nil {
 			return "", err
 		}
-
-		fmt.Printf("x: %s\n", x)
 		return string(x), nil
 	case "json":
 		x, err := json.Marshal(cm.ConfigData.SystemConfiguration)
 		if err != nil {
 			return "", err
 		}
-
-		fmt.Printf("x: %s\n", x)
 		return string(x), nil
 	default:
 		return "", UnknownConfigFormatError(strings.ToLower(cm.ConfigFormat))

--- a/config/dell.go
+++ b/config/dell.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"strings"
 )
 
@@ -33,8 +34,8 @@ type dellComponent struct {
 type dellComponentAttribute struct {
 	XMLName     xml.Name `xml:"Attribute"`
 	Name        string   `xml:"Name,attr" json:"Name"`
-	SetOnImport bool     `json:"SetOnImport"`
-	Comment     string   `json:"Comment"`
+	SetOnImport bool     `json:"SetOnImport,omitempty"`
+	Comment     string   `json:"Comment,omitempty"`
 	Value       string   `xml:",chardata" json:"Value"`
 }
 
@@ -107,6 +108,7 @@ func (cm *dellVendorConfig) Marshal() (string, error) {
 			return "", err
 		}
 
+		fmt.Printf("x: %s\n", x)
 		return string(x), nil
 	case "json":
 		x, err := json.Marshal(cm.ConfigData.SystemConfiguration)
@@ -114,6 +116,7 @@ func (cm *dellVendorConfig) Marshal() (string, error) {
 			return "", err
 		}
 
+		fmt.Printf("x: %s\n", x)
 		return string(x), nil
 	default:
 		return "", UnknownConfigFormatError(strings.ToLower(cm.ConfigFormat))

--- a/config/dell.go
+++ b/config/dell.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"strings"
+)
+
+type dellVendorConfig struct {
+	ConfigFormat string
+	ConfigData   *dellConfig
+}
+
+type dellConfig struct {
+	SystemConfiguration *dellSystemConfiguration `xml:"SystemConfiguration" json:"SystemConfiguration"`
+}
+
+type dellSystemConfiguration struct {
+	XMLName    xml.Name         `xml:"SystemConfiguration"`
+	Model      string           `xml:"Model,attr" json:"Model"`
+	Comments   []string         `xml:"Comments>Comment,omitempty" json:"Comments,omitempty" `
+	ServiceTag string           `xml:"ServiceTag,attr" json:"ServiceTag"`
+	TimeStamp  string           `xml:"TimeStamp,attr" json:"TimeStamp"`
+	Components []*dellComponent `xml:"Component" json:"Components"`
+}
+
+type dellComponent struct {
+	XMLName    xml.Name                  `xml:"Component"`
+	FQDD       string                    `xml:"FQDD,attr" json:"FQDD"`
+	Attributes []*dellComponentAttribute `xml:"Attribute" json:"Attributes"`
+}
+
+type dellComponentAttribute struct {
+	XMLName     xml.Name `xml:"Attribute"`
+	Name        string   `xml:"Name,attr" json:"Name"`
+	SetOnImport bool     `json:"SetOnImport"`
+	Comment     string   `json:"Comment"`
+	Value       string   `xml:",chardata" json:"Value"`
+}
+
+func NewDellVendorConfigManager(configFormat string) (VendorConfigManager, error) {
+	dell := &dellVendorConfig{}
+
+	switch strings.ToLower(configFormat) {
+	case "xml", "json":
+		dell.ConfigFormat = strings.ToLower(configFormat)
+	default:
+		return nil, UnknownConfigFormatError(strings.ToLower(configFormat))
+	}
+
+	dell.ConfigData = &dellConfig{
+		SystemConfiguration: &dellSystemConfiguration{},
+	}
+
+	return dell, nil
+}
+
+// FindComponent locates an existing DellComponent if one exists in the ConfigData, if not
+// it creates one and returns a pointer to that.
+func (cm *dellVendorConfig) FindComponent(fqdd string) (c *dellComponent) {
+	for _, c = range cm.ConfigData.SystemConfiguration.Components {
+		if c.FQDD == fqdd {
+			return
+		}
+	}
+
+	c.FQDD = fqdd
+
+	cm.ConfigData.SystemConfiguration.Components = append(cm.ConfigData.SystemConfiguration.Components, c)
+
+	return
+}
+
+// FindComponentAttribute locates an existing DellComponentAttribute if one exists in the
+// ConfigData, if not it creates one and returns a pointer to that.
+func (cm *dellVendorConfig) FindComponentAttribute(c *dellComponent, name string) (a *dellComponentAttribute) {
+	for _, a = range c.Attributes {
+		if a.Name == name {
+			return
+		}
+	}
+
+	a.Name = name
+
+	c.Attributes = append(c.Attributes, a)
+
+	return
+}
+
+func (cm *dellVendorConfig) Raw(name, value string, menuPath []string) {
+	c := cm.FindComponent(menuPath[0])
+	attr := cm.FindComponentAttribute(c, name)
+	attr.Value = value
+}
+
+func (cm *dellVendorConfig) Marshal() (string, error) {
+	switch strings.ToLower(cm.ConfigFormat) {
+	case "xml":
+		x, err := xml.Marshal(cm.ConfigData)
+		if err != nil {
+			return "", err
+		}
+
+		return string(x), nil
+	case "json":
+		x, err := json.Marshal(cm.ConfigData)
+		if err != nil {
+			return "", err
+		}
+
+		return string(x), nil
+	default:
+		return "", UnknownConfigFormatError(strings.ToLower(cm.ConfigFormat))
+	}
+}
+
+// Generic config options
+
+func (cm *dellVendorConfig) EnableTPM() {
+	cm.Raw("EnableTPM", "Enabled", []string{"BIOS.Setup.1-1"})
+}
+
+func (cm *dellVendorConfig) EnableSRIOV() {
+	// TODO(jwb) How do we want to handle enabling this for different NICs
+	cm.Raw("VirtualizationMode", "SRIOV", []string{"NIC.Slot.3-1-1"})
+}

--- a/config/errors.go
+++ b/config/errors.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+)
+
+var errUnknownConfigFormat = errors.New("unknown config format")
+var errUnknownVendor = errors.New("unknown/unsupported vendor")
+
+func UnknownConfigFormatError(format string) error {
+	return fmt.Errorf("unknown config format %w : %s", errUnknownConfigFormat, format)
+}
+
+func UnknownVendorError(vendorName string) error {
+	return fmt.Errorf("unknown/unsupported vendor %w : %s", errUnknownVendor, vendorName)
+}

--- a/config/interface.go
+++ b/config/interface.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/bmc-toolbox/common"
+)
+
+type VendorConfigManager interface {
+	EnableTPM()
+	EnableSRIOV()
+
+	Raw(name, value string, menuPath []string)
+	Marshal() (string, error)
+}
+
+func NewVendorConfigManager(configFormat, vendorName string) (VendorConfigManager, error) {
+	switch strings.ToLower(vendorName) {
+	case common.VendorDell:
+		return NewDellVendorConfigManager(configFormat)
+	case common.VendorSupermicro:
+		return NewSupermicroVendorConfigManager(configFormat)
+	case common.VendorAsrockrack:
+		return NewAsrockrackVendorConfigManager(configFormat)
+	default:
+		return nil, UnknownVendorError(strings.ToLower(vendorName))
+	}
+}

--- a/config/interface.go
+++ b/config/interface.go
@@ -14,14 +14,14 @@ type VendorConfigManager interface {
 	Marshal() (string, error)
 }
 
-func NewVendorConfigManager(configFormat, vendorName string) (VendorConfigManager, error) {
+func NewVendorConfigManager(configFormat, vendorName string, vendorOptions map[string]string) (VendorConfigManager, error) {
 	switch strings.ToLower(vendorName) {
 	case common.VendorDell:
-		return NewDellVendorConfigManager(configFormat)
+		return NewDellVendorConfigManager(configFormat, vendorOptions)
 	case common.VendorSupermicro:
-		return NewSupermicroVendorConfigManager(configFormat)
+		return NewSupermicroVendorConfigManager(configFormat, vendorOptions)
 	case common.VendorAsrockrack:
-		return NewAsrockrackVendorConfigManager(configFormat)
+		return NewAsrockrackVendorConfigManager(configFormat, vendorOptions)
 	default:
 		return nil, UnknownVendorError(strings.ToLower(vendorName))
 	}

--- a/config/supermicro.go
+++ b/config/supermicro.go
@@ -34,7 +34,7 @@ type supermicroBiosCfgSetting struct {
 	Type           string   `xml:"type,attr"`
 }
 
-func NewSupermicroVendorConfigManager(configFormat string) (VendorConfigManager, error) {
+func NewSupermicroVendorConfigManager(configFormat string, vendorOptions map[string]string) (VendorConfigManager, error) {
 	supermicro := &supermicroVendorConfig{}
 
 	switch strings.ToLower(configFormat) {

--- a/config/supermicro.go
+++ b/config/supermicro.go
@@ -1,0 +1,127 @@
+package config
+
+import (
+	"encoding/xml"
+	"strings"
+)
+
+type supermicroVendorConfig struct {
+	ConfigFormat string
+	ConfigData   *supermicroConfig
+}
+
+type supermicroConfig struct {
+	BiosCfg *supermicroBiosCfg `xml:"BiosCfg"`
+}
+
+type supermicroBiosCfg struct {
+	XMLName xml.Name                 `xml:"BiosCfg"`
+	Menus   []*supermicroBiosCfgMenu `xml:"Menu"`
+}
+
+type supermicroBiosCfgMenu struct {
+	XMLName  xml.Name                    `xml:"Menu"`
+	Name     string                      `xml:"name,attr"`
+	Settings []*supermicroBiosCfgSetting `xml:"Setting"`
+	Menus    []*supermicroBiosCfgMenu    `xml:"Menu"`
+}
+
+type supermicroBiosCfgSetting struct {
+	XMLName        xml.Name `xml:"Setting"`
+	Name           string   `xml:"Name,attr"`
+	Order          string   `xml:"order,attr"`
+	SelectedOption string   `xml:"selectedOption,attr"`
+	Type           string   `xml:"type,attr"`
+}
+
+func NewSupermicroVendorConfigManager(configFormat string) (VendorConfigManager, error) {
+	supermicro := &supermicroVendorConfig{}
+
+	switch strings.ToLower(configFormat) {
+	case "xml":
+		supermicro.ConfigFormat = strings.ToLower(configFormat)
+	default:
+		return nil, UnknownConfigFormatError(strings.ToLower(configFormat))
+	}
+
+	supermicro.ConfigData = &supermicroConfig{
+		BiosCfg: &supermicroBiosCfg{},
+	}
+
+	return supermicro, nil
+}
+
+// FindMenu locates an existing SupermicroBiosCfgMenu if one exists in the ConfigData, if not
+// it creates one and returns a pointer to that.
+func (cm *supermicroVendorConfig) FindMenu(menuName string, menuRoot *supermicroBiosCfgMenu) (m *supermicroBiosCfgMenu) {
+	// root is cm.ConfigData.BiosCfg.Menus
+	for _, m = range menuRoot.Menus {
+		if m.Name == menuName {
+			return
+		}
+	}
+
+	m.Name = menuName
+
+	menuRoot.Menus = append(menuRoot.Menus, m)
+
+	return
+}
+
+// FindMenuSetting locates an existing SupermicroBiosCfgSetting if one exists in the
+// ConfigData, if not it creates one and returns a pointer to that.
+func (cm *supermicroVendorConfig) FindMenuSetting(m *supermicroBiosCfgMenu, name string) (s *supermicroBiosCfgSetting) {
+	for _, s = range m.Settings {
+		if s.Name == name {
+			return
+		}
+	}
+
+	s.Name = name
+
+	m.Settings = append(m.Settings, s)
+
+	return
+}
+
+// TODO(jwb) How do we handle the random nature of sub menus here..   we could make the user pass the explicit pointer to a menu struct, or..
+func (cm *supermicroVendorConfig) Raw(name, value string, menuPath []string) {
+	menus := make([]*supermicroBiosCfgMenu, 0, len(menuPath))
+
+	for i, name := range menuPath {
+		var m *supermicroBiosCfgMenu
+
+		if i == 0 {
+			m = cm.FindMenu(name, cm.ConfigData.BiosCfg.Menus[0])
+		} else {
+			m = cm.FindMenu(name, menus[i-1])
+		}
+
+		menus = append(menus, m)
+	}
+}
+
+func (cm *supermicroVendorConfig) Marshal() (string, error) {
+	switch strings.ToLower(cm.ConfigFormat) {
+	case "xml":
+		x, err := xml.Marshal(cm.ConfigData)
+		if err != nil {
+			return "", err
+		}
+
+		return string(x), nil
+	default:
+		return "", UnknownConfigFormatError(strings.ToLower(cm.ConfigFormat))
+	}
+}
+
+// Generic config options
+
+func (cm *supermicroVendorConfig) EnableTPM() {
+	cm.Raw("  Security Device Support", "Enable", []string{"Trusted Computing"})
+	cm.Raw("  SHA-1 PCR Bank", "Enabled", []string{"Trusted Computing"})
+}
+
+func (cm *supermicroVendorConfig) EnableSRIOV() {
+	cm.Raw("SR-IOV Support", "Enabled", []string{"Advanced", "PCIe/PCI/PnP Configuration"})
+}

--- a/config/supermicro.go
+++ b/config/supermicro.go
@@ -84,7 +84,6 @@ func (cm *supermicroVendorConfig) FindMenuSetting(m *supermicroBiosCfgMenu, name
 	return
 }
 
-// TODO(jwb) How do we handle the random nature of sub menus here..   we could make the user pass the explicit pointer to a menu struct, or..
 func (cm *supermicroVendorConfig) Raw(name, value string, menuPath []string) {
 	menus := make([]*supermicroBiosCfgMenu, 0, len(menuPath))
 


### PR DESCRIPTION
## What does this PR implement/change/remove?

A set of vendor config format providers that aid in the translation of hw config options from one vendor to another.  (Primarily for BIOS/BMC config settings) 

### Checklist
- [ ] Tests added
- [ ] Similar commits squashed

### The HW vendor this change applies to (if applicable)
* Dell, Supermicro and asrockrack

## Description for changelog/release notes

Adds a set of vendor config format providers that aid in the translation of hw config options from one vendor to another.  (Primarily for BIOS/BMC config settings) 
