### PR TITLE
Add Unmarshal(cfg string) to VendorConfigManager

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,5 +18,5 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        args: -v --config .golangci.yml --timeout=5m
+        args: -v --config .golangci.yml --timeout=5m --out-format=colored-line-number
         version: latest

--- a/config/asrockrack.go
+++ b/config/asrockrack.go
@@ -110,6 +110,10 @@ func (cm *asrockrackVendorConfig) Unmarshal(cfgData string) (err error) {
 	return
 }
 
+func (cm *asrockrackVendorConfig) StandardConfig() (biosConfig map[string]string, err error) {
+	return
+}
+
 // Generic config options
 
 func (cm *asrockrackVendorConfig) EnableTPM() {

--- a/config/asrockrack.go
+++ b/config/asrockrack.go
@@ -110,7 +110,7 @@ func (cm *asrockrackVendorConfig) Unmarshal(cfgData string) error {
 }
 
 func (cm *asrockrackVendorConfig) StandardConfig() (biosConfig map[string]string, err error) {
-	return
+	return biosConfig, err
 }
 
 // Generic config options

--- a/config/asrockrack.go
+++ b/config/asrockrack.go
@@ -105,9 +105,8 @@ func (cm *asrockrackVendorConfig) Marshal() (string, error) {
 	}
 }
 
-func (cm *asrockrackVendorConfig) Unmarshal(cfgData string) (err error) {
-	err = xml.Unmarshal([]byte(cfgData), cm.ConfigData)
-	return
+func (cm *asrockrackVendorConfig) Unmarshal(cfgData string) error {
+	return xml.Unmarshal([]byte(cfgData), cm.ConfigData)
 }
 
 func (cm *asrockrackVendorConfig) StandardConfig() (biosConfig map[string]string, err error) {

--- a/config/asrockrack.go
+++ b/config/asrockrack.go
@@ -120,6 +120,11 @@ func (cm *asrockrackVendorConfig) BootOrder(mode string) error {
 	return
 }
 
+func (cm *asrockrackVendorConfig) BootMode(mode string) error {
+	// Unimplemented
+	return
+}
+
 func (cm *asrockrackVendorConfig) EnableTPM() {
 	// Unimplemented
 }

--- a/config/asrockrack.go
+++ b/config/asrockrack.go
@@ -117,37 +117,37 @@ func (cm *asrockrackVendorConfig) StandardConfig() (biosConfig map[string]string
 
 func (cm *asrockrackVendorConfig) BootOrder(mode string) error {
 	// Unimplemented
-	return
+	return nil
 }
 
 func (cm *asrockrackVendorConfig) BootMode(mode string) error {
 	// Unimplemented
-	return
+	return nil
 }
 
 func (cm *asrockrackVendorConfig) IntelSGX(mode string) error {
 	// Unimplemented
-	return
+	return nil
 }
 
 func (cm *asrockrackVendorConfig) SecureBoot(enable bool) error {
 	// Unimplemented
-	return
+	return nil
 }
 
 func (cm *asrockrackVendorConfig) TPM(enable bool) error {
 	// Unimplemented
-	return
+	return nil
 }
 
 func (cm *asrockrackVendorConfig) SMT(enable bool) error {
 	// Unimplemented
-	return
+	return nil
 }
 
 func (cm *asrockrackVendorConfig) SRIOV(enable bool) error {
 	// Unimplemented
-	return
+	return nil
 }
 
 func (cm *asrockrackVendorConfig) EnableTPM() {

--- a/config/asrockrack.go
+++ b/config/asrockrack.go
@@ -105,6 +105,11 @@ func (cm *asrockrackVendorConfig) Marshal() (string, error) {
 	}
 }
 
+func (cm *asrockrackVendorConfig) Unmarshal(cfgData string) (err error) {
+	err = xml.Unmarshal([]byte(cfgData), cm.ConfigData)
+	return
+}
+
 // Generic config options
 
 func (cm *asrockrackVendorConfig) EnableTPM() {

--- a/config/asrockrack.go
+++ b/config/asrockrack.go
@@ -115,6 +115,11 @@ func (cm *asrockrackVendorConfig) StandardConfig() (biosConfig map[string]string
 
 // Generic config options
 
+func (cm *asrockrackVendorConfig) BootOrder(mode string) error {
+	// Unimplemented
+	return
+}
+
 func (cm *asrockrackVendorConfig) EnableTPM() {
 	// Unimplemented
 }

--- a/config/asrockrack.go
+++ b/config/asrockrack.go
@@ -125,6 +125,31 @@ func (cm *asrockrackVendorConfig) BootMode(mode string) error {
 	return
 }
 
+func (cm *asrockrackVendorConfig) IntelSGX(mode string) error {
+	// Unimplemented
+	return
+}
+
+func (cm *asrockrackVendorConfig) SecureBoot(enable bool) error {
+	// Unimplemented
+	return
+}
+
+func (cm *asrockrackVendorConfig) TPM(enable bool) error {
+	// Unimplemented
+	return
+}
+
+func (cm *asrockrackVendorConfig) SMT(enable bool) error {
+	// Unimplemented
+	return
+}
+
+func (cm *asrockrackVendorConfig) SRIOV(enable bool) error {
+	// Unimplemented
+	return
+}
+
 func (cm *asrockrackVendorConfig) EnableTPM() {
 	// Unimplemented
 }

--- a/config/dell.go
+++ b/config/dell.go
@@ -129,9 +129,8 @@ func (cm *dellVendorConfig) Marshal() (string, error) {
 	}
 }
 
-func (cm *dellVendorConfig) Unmarshal(cfgData string) (err error) {
-	err = xml.Unmarshal([]byte(cfgData), cm.ConfigData)
-	return
+func (cm *dellVendorConfig) Unmarshal(cfgData string) error {
+	return xml.Unmarshal([]byte(cfgData), cm.ConfigData)
 }
 
 func (cm *dellVendorConfig) StandardConfig() (biosConfig map[string]string, err error) {

--- a/config/dell.go
+++ b/config/dell.go
@@ -144,6 +144,11 @@ func (cm *dellVendorConfig) BootOrder(mode string) error {
 	return
 }
 
+func (cm *dellVendorConfig) BootMode(mode string) error {
+	// Unimplemented
+	return
+}
+
 func (cm *dellVendorConfig) EnableTPM() {
 	cm.Raw("EnableTPM", "Enabled", []string{"BIOS.Setup.1-1"})
 }

--- a/config/dell.go
+++ b/config/dell.go
@@ -134,7 +134,7 @@ func (cm *dellVendorConfig) Unmarshal(cfgData string) error {
 }
 
 func (cm *dellVendorConfig) StandardConfig() (biosConfig map[string]string, err error) {
-	return
+	return biosConfig, err
 }
 
 // Generic config options

--- a/config/dell.go
+++ b/config/dell.go
@@ -149,6 +149,32 @@ func (cm *dellVendorConfig) BootMode(mode string) error {
 	return
 }
 
+func (cm *dellVendorConfig) IntelSGX(mode string) error {
+	// Unimplemented
+	return
+}
+
+func (cm *dellVendorConfig) SecureBoot(enable bool) error {
+	// Unimplemented
+	return
+}
+
+func (cm *dellVendorConfig) TPM(enable bool) error {
+	// Unimplemented
+	return
+}
+
+func (cm *dellVendorConfig) SMT(enable bool) error {
+	// Unimplemented
+	return
+}
+
+func (cm *dellVendorConfig) SRIOV(enable bool) error {
+	// Unimplemented
+	return
+}
+
+
 func (cm *dellVendorConfig) EnableTPM() {
 	cm.Raw("EnableTPM", "Enabled", []string{"BIOS.Setup.1-1"})
 }

--- a/config/dell.go
+++ b/config/dell.go
@@ -139,6 +139,11 @@ func (cm *dellVendorConfig) StandardConfig() (biosConfig map[string]string, err 
 
 // Generic config options
 
+func (cm *dellVendorConfig) BootOrder(mode string) error {
+	// Unimplemented
+	return
+}
+
 func (cm *dellVendorConfig) EnableTPM() {
 	cm.Raw("EnableTPM", "Enabled", []string{"BIOS.Setup.1-1"})
 }

--- a/config/dell.go
+++ b/config/dell.go
@@ -129,6 +129,11 @@ func (cm *dellVendorConfig) Marshal() (string, error) {
 	}
 }
 
+func (cm *dellVendorConfig) Unmarshal(cfgData string) (err error) {
+	err = xml.Unmarshal([]byte(cfgData), cm.ConfigData)
+	return
+}
+
 // Generic config options
 
 func (cm *dellVendorConfig) EnableTPM() {

--- a/config/dell.go
+++ b/config/dell.go
@@ -134,6 +134,10 @@ func (cm *dellVendorConfig) Unmarshal(cfgData string) (err error) {
 	return
 }
 
+func (cm *dellVendorConfig) StandardConfig() (biosConfig map[string]string, err error) {
+	return
+}
+
 // Generic config options
 
 func (cm *dellVendorConfig) EnableTPM() {

--- a/config/dell.go
+++ b/config/dell.go
@@ -141,39 +141,38 @@ func (cm *dellVendorConfig) StandardConfig() (biosConfig map[string]string, err 
 
 func (cm *dellVendorConfig) BootOrder(mode string) error {
 	// Unimplemented
-	return
+	return nil
 }
 
 func (cm *dellVendorConfig) BootMode(mode string) error {
 	// Unimplemented
-	return
+	return nil
 }
 
 func (cm *dellVendorConfig) IntelSGX(mode string) error {
 	// Unimplemented
-	return
+	return nil
 }
 
 func (cm *dellVendorConfig) SecureBoot(enable bool) error {
 	// Unimplemented
-	return
+	return nil
 }
 
 func (cm *dellVendorConfig) TPM(enable bool) error {
 	// Unimplemented
-	return
+	return nil
 }
 
 func (cm *dellVendorConfig) SMT(enable bool) error {
 	// Unimplemented
-	return
+	return nil
 }
 
 func (cm *dellVendorConfig) SRIOV(enable bool) error {
 	// Unimplemented
-	return
+	return nil
 }
-
 
 func (cm *dellVendorConfig) EnableTPM() {
 	cm.Raw("EnableTPM", "Enabled", []string{"BIOS.Setup.1-1"})

--- a/config/errors.go
+++ b/config/errors.go
@@ -7,9 +7,14 @@ import (
 
 var errUnknownConfigFormat = errors.New("unknown config format")
 var errUnknownVendor = errors.New("unknown/unsupported vendor")
+var errUnknownSettingType = errors.New("unknown setting type")
 
 func UnknownConfigFormatError(format string) error {
 	return fmt.Errorf("unknown config format %w : %s", errUnknownConfigFormat, format)
+}
+
+func UnknownSettingType(t string) error {
+	return fmt.Errorf("unknown setting type %w : %s", errUnknownSettingType, t)
 }
 
 func UnknownVendorError(vendorName string) error {

--- a/config/errors.go
+++ b/config/errors.go
@@ -9,6 +9,9 @@ var errUnknownConfigFormat = errors.New("unknown config format")
 var errUnknownVendor = errors.New("unknown/unsupported vendor")
 var errUnknownSettingType = errors.New("unknown setting type")
 
+var errInvalidBootModeOption = errors.New("invalid BootMode option <LEGACY|UEFI|DUAL>")
+var errInvalidSGXOption = errors.New("invalid SGX option <Enabled|Disabled|Software Controlled>")
+
 func UnknownConfigFormatError(format string) error {
 	return fmt.Errorf("unknown config format %w : %s", errUnknownConfigFormat, format)
 }
@@ -19,4 +22,12 @@ func UnknownSettingType(t string) error {
 
 func UnknownVendorError(vendorName string) error {
 	return fmt.Errorf("unknown/unsupported vendor %w : %s", errUnknownVendor, vendorName)
+}
+
+func InvalidBootModeOption(mode string) error {
+	return fmt.Errorf("%w : %s", errInvalidBootModeOption, mode)
+}
+
+func InvalidSGXOption(mode string) error {
+	return fmt.Errorf("%w : %s", errInvalidSGXOption, mode)
 }

--- a/config/interface.go
+++ b/config/interface.go
@@ -13,6 +13,7 @@ type VendorConfigManager interface {
 	Raw(name, value string, menuPath []string)
 	Marshal() (string, error)
 	Unmarshal(cfgData string) (err error)
+	StandardConfig() (biosConfig map[string]string, err error)
 }
 
 func NewVendorConfigManager(configFormat, vendorName string, vendorOptions map[string]string) (VendorConfigManager, error) {

--- a/config/interface.go
+++ b/config/interface.go
@@ -12,6 +12,7 @@ type VendorConfigManager interface {
 
 	Raw(name, value string, menuPath []string)
 	Marshal() (string, error)
+	Unmarshal(cfgData string) (err error)
 }
 
 func NewVendorConfigManager(configFormat, vendorName string, vendorOptions map[string]string) (VendorConfigManager, error) {

--- a/config/interface.go
+++ b/config/interface.go
@@ -7,13 +7,18 @@ import (
 )
 
 type VendorConfigManager interface {
-	EnableTPM()
-	EnableSRIOV()
-
 	Raw(name, value string, menuPath []string)
 	Marshal() (string, error)
 	Unmarshal(cfgData string) (err error)
 	StandardConfig() (biosConfig map[string]string, err error)
+
+	BootMode(mode string) error
+	BootOrder(mode string) error
+	IntelSGX(mode string) error
+	SecureBoot(enable bool) error
+	TPM(enable bool) error
+	SMT(enable bool) error
+	SRIOV(enable bool) error
 }
 
 func NewVendorConfigManager(configFormat, vendorName string, vendorOptions map[string]string) (VendorConfigManager, error) {

--- a/config/supermicro.go
+++ b/config/supermicro.go
@@ -78,17 +78,20 @@ func (cm *supermicroVendorConfig) FindOrCreateSetting(path []string, value strin
 						return (*currentMenus)[j].Settings[k]
 					}
 				}
-
-				newSetting := &supermicroBiosCfgSetting{Name: part, SelectedOption: value}
-				(*currentMenus)[j].Settings = append((*currentMenus)[j].Settings, newSetting)
-				return (*currentMenus)[j].Settings[len((*currentMenus)[j].Settings)-1]
 			}
+
+			// If no setting found in any menu, create a new setting in the first menu
+			newSetting := supermicroBiosCfgSetting{Name: part, SelectedOption: ""}
+			(*currentMenus)[0].Settings = append((*currentMenus)[0].Settings, &newSetting)
+
+			return (*currentMenus)[0].Settings[len((*currentMenus)[0].Settings)-1]
 		} else {
 			// Intermediate part, find or create the menu
 			currentMenu := cm.FindOrCreateMenu(currentMenus, part)
 			currentMenus = &currentMenu.Menus
 		}
 	}
+
 	return nil
 }
 

--- a/config/supermicro.go
+++ b/config/supermicro.go
@@ -129,12 +129,7 @@ func (cm *supermicroVendorConfig) Unmarshal(cfgData string) (err error) {
 	// convert characters from non-UTF-8 to UTF-8
 	decoder.CharsetReader = charset.NewReaderLabel
 
-	err = decoder.Decode(cm.ConfigData.BiosCfg)
-	if err != nil {
-		return err
-	}
-
-	return
+	return decoder.Decode(cm.ConfigData.BiosCfg)
 }
 
 func (cm *supermicroVendorConfig) StandardConfig() (biosConfig map[string]string, err error) {
@@ -254,6 +249,9 @@ func (cm *supermicroVendorConfig) BootMode(mode string) error {
 }
 
 func (cm *supermicroVendorConfig) BootOrder(mode string) error {
+	// In a supermicro config there are 8 total legacy boot options and 9 UEFI boot options
+	// Since we primarily care about the first two boot options we explicitly define them
+	// and rely on the for loop to populate the remainder as Disabled.
 	switch strings.ToUpper(mode) {
 	case "LEGACY":
 		cm.Raw("Legacy Boot Option #1", "Hard Disk", []string{"Boot"})

--- a/config/supermicro.go
+++ b/config/supermicro.go
@@ -114,6 +114,11 @@ func (cm *supermicroVendorConfig) Marshal() (string, error) {
 	}
 }
 
+func (cm *supermicroVendorConfig) Unmarshal(cfgData string) (err error) {
+	err = xml.Unmarshal([]byte(cfgData), cm.ConfigData)
+	return
+}
+
 // Generic config options
 
 func (cm *supermicroVendorConfig) EnableTPM() {

--- a/config/supermicro.go
+++ b/config/supermicro.go
@@ -151,6 +151,7 @@ func (cm *supermicroVendorConfig) StandardConfig() (biosConfig map[string]string
 			default:
 				var k, v string
 				k, v, err = normalizeSetting(s)
+
 				if err != nil {
 					return
 				}

--- a/config/supermicro.go
+++ b/config/supermicro.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"encoding/xml"
+	"fmt"
 	"strings"
 
 	"golang.org/x/net/html/charset"
@@ -66,7 +67,7 @@ func NewSupermicroVendorConfigManager(configFormat string, vendorOptions map[str
 func (cm *supermicroVendorConfig) FindOrCreateSetting(path []string, value string) *supermicroBiosCfgSetting {
 	biosCfg := cm.ConfigData.BiosCfg
 
-	var currentMenus *[]*supermicroBiosCfgMenu = &biosCfg.Menus
+	var currentMenus = &biosCfg.Menus
 
 	for i, part := range path {
 		if i == len(path)-1 {
@@ -98,8 +99,10 @@ func (cm *supermicroVendorConfig) FindOrCreateMenu(menus *[]*supermicroBiosCfgMe
 			return (*menus)[i]
 		}
 	}
+
 	newMenu := &supermicroBiosCfgMenu{Name: name}
 	*menus = append(*menus, newMenu)
+
 	return (*menus)[len(*menus)-1]
 }
 
@@ -256,14 +259,16 @@ func (cm *supermicroVendorConfig) BootOrder(mode string) error {
 	case "LEGACY":
 		cm.Raw("Legacy Boot Option #1", "Hard Disk", []string{"Boot"})
 		cm.Raw("Legacy Boot Option #2", "Network", []string{"Boot"})
+
 		for i := 3; i < 8; i++ {
-			cm.Raw("Legacy Boot Option #"+string(i), "Disabled", []string{"Boot"})
+			cm.Raw("Legacy Boot Option #"+fmt.Sprint(i), "Disabled", []string{"Boot"})
 		}
 	case "UEFI":
 		cm.Raw("UEFI Boot Option #1", "UEFI Hard Disk", []string{"Boot"})
 		cm.Raw("UEFI Boot Option #2", "UEFI Network", []string{"Boot"})
+
 		for i := 3; i < 9; i++ {
-			cm.Raw("UEFI Boot Option #"+string(i), "Disabled", []string{"Boot"})
+			cm.Raw("UEFI Boot Option #"+fmt.Sprint(i), "Disabled", []string{"Boot"})
 		}
 	case "DUAL":
 		// TODO(jwb) Is this just both sets?
@@ -287,11 +292,10 @@ func (cm *supermicroVendorConfig) IntelSGX(mode string) error {
 }
 
 func (cm *supermicroVendorConfig) SecureBoot(enable bool) error {
-	if enable {
-		cm.Raw("Secure Boot", "Enabled", []string{"SMC Secure Boot Configuration"})
-		// cm.Raw("Secure Boot Mode", "Setup", []string{"SMC Secure Boot Configuration"})
-	} else {
+	if !enable {
 		cm.Raw("Secure Boot", "Disabled", []string{"SMC Secure Boot Configuration"})
+	} else {
+		cm.Raw("Secure Boot", "Enabled", []string{"SMC Secure Boot Configuration"})
 	}
 
 	return nil
@@ -323,6 +327,5 @@ func (cm *supermicroVendorConfig) SMT(enable bool) error {
 
 func (cm *supermicroVendorConfig) SRIOV(enable bool) error {
 	// TODO(jwb) Need to figure out how we do this on platforms that support it...
-
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/bmc-toolbox/common
 
 go 1.17
+
+require golang.org/x/net v0.25.0
+
+require golang.org/x/text v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=
+golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
+golang.org/x/text v0.15.0 h1:h1V/4gjBv8v9cjcR6+AR5+/cIYK5N/WAgiv4xlsEtAk=
+golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=


### PR DESCRIPTION
## What does this PR implement/change/remove?

Adds a function to each VendorConfigManager with the signature Unmarshal(cfg string) that takes a vendor-specific raw config file (as a string) and parses that content into the vendor specific configuration structs.

Additionally, this commit also provides functions for config/supermicro that convert a vendor specific config file into a generic map[string]string normalized across vendors.

### The HW vendor this change applies to (if applicable)

Supermicro primarily.

## Description for changelog/release notes

```
* Add Unmarshal(cfg string) to VendorConfigManager
* Add supermicro configuration normalization functions to config/supermicro
```
